### PR TITLE
remove dependence on global `analysis_inputs_path` from `get_entity_info()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Suggests: 
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 Config/testthat/edition: 3
 Imports: 
     DBI,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pacta.portfolio.audit (development version)
 
+* `get_entity_info()` gains a `dir` argument allowing one to explicitly pass the `analysis_inputs_path` value rather than depending on it being available in the global environment
+
 * Add vignette/article Attributing Company Activities to Financial Assets (#12)
 
 * Calculate the number of shares for component holdings of funds when they are expanded, which results in an appropriate ownership weight being calculated (rather than always 0 as before) for equity indirectly held through a fund (#12)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pacta.portfolio.audit (development version)
 
-* `get_entity_info()` gains a `dir` argument allowing one to explicitly pass the `analysis_inputs_path` value rather than depending on it being available in the global environment
+* `get_entity_info()` gains a `dir` argument allowing one to explicitly pass the `analysis_inputs_path` value rather than depending on it being available in the global environment, while the default behavior maintains backward compatibility with previous workflows (#17)
 
 * Add vignette/article Attributing Company Activities to Financial Assets (#12)
 

--- a/R/get_entity_info.R
+++ b/R/get_entity_info.R
@@ -6,13 +6,13 @@
 #'
 #' @export
 
-get_entity_info <- function() {
-  sqlite_path <- file.path(.GlobalEnv$analysis_inputs_path, "entity_info.sqlite")
+get_entity_info <- function(dir = .GlobalEnv$analysis_inputs_path) {
+  sqlite_path <- file.path(dir, "entity_info.sqlite")
   if (file.exists(sqlite_path)) {
     class(sqlite_path) <- c("db_path", "character")
     return(sqlite_path)
   } else {
-    entity_info <- readr::read_rds(file.path(.GlobalEnv$analysis_inputs_path, "entity_info.rds"))
+    entity_info <- readr::read_rds(file.path(dir, "entity_info.rds"))
     return(entity_info)
   }
 }

--- a/R/get_entity_info.R
+++ b/R/get_entity_info.R
@@ -2,6 +2,10 @@
 #'
 #' A longer description of the function
 #'
+#' @param dir A string containing the path to the directory where the entity
+#'   info files should be found, typically the value of the
+#'   `analysis_inputs_path` parameter
+#'
 #' @return A description of the return value
 #'
 #' @export

--- a/man/get_entity_info.Rd
+++ b/man/get_entity_info.Rd
@@ -4,7 +4,12 @@
 \alias{get_entity_info}
 \title{A short description of the function}
 \usage{
-get_entity_info()
+get_entity_info(dir = .GlobalEnv$analysis_inputs_path)
+}
+\arguments{
+\item{dir}{A string containing the path to the directory where the entity
+info files should be found, typically the value of the
+\code{analysis_inputs_path} parameter}
 }
 \value{
 A description of the return value

--- a/tests/testthat/test-get_entity_info.R
+++ b/tests/testthat/test-get_entity_info.R
@@ -1,0 +1,51 @@
+test_that("works as expected with global `analysis_inputs_path`", {
+  with_global_analysis_inputs_path <- function (new, code) {
+    if (exists("analysis_inputs_path", envir = .GlobalEnv)) {
+      old <- .GlobalEnv$analysis_inputs_path
+      .GlobalEnv$analysis_inputs_path <- new
+      on.exit(.GlobalEnv$analysis_inputs_path <- old)
+      force(code)
+    } else {
+      .GlobalEnv$analysis_inputs_path <- new
+      on.exit(rm(analysis_inputs_path, envir = .GlobalEnv))
+      force(code)
+    }
+  }
+
+  withr::local_file(list(
+    "entity_info.sqlite" = writeLines("foo", "entity_info.sqlite"),
+    "entity_info.rds" = saveRDS("foo", "entity_info.rds")
+  ))
+
+  expect_no_error(
+    with_global_analysis_inputs_path(".", get_entity_info())
+  )
+
+  expect_equal(
+    with_global_analysis_inputs_path(".", get_entity_info()),
+    "./entity_info.sqlite",
+    ignore_attr = TRUE
+  )
+
+  withr::deferred_run()
+
+  withr::local_file(list(
+    "entity_info.rds" = saveRDS("foo", "entity_info.rds")
+  ))
+
+  expect_no_error(
+    with_global_analysis_inputs_path(".", get_entity_info())
+  )
+
+  expect_equal(
+    with_global_analysis_inputs_path(".", get_entity_info()),
+    "foo",
+    ignore_attr = TRUE
+  )
+
+  withr::deferred_run()
+
+  expect_error(
+    with_global_analysis_inputs_path(".", suppressWarnings(get_entity_info()))
+  )
+})


### PR DESCRIPTION
First commit adds a test so that the current usage, i.e. `get_entity_info()`, works as expected with no argument and a dependence on an `analysis_inputs_path` object being available in the global environment. This required a convoluted `withr` usage to safely construct and teardown an appropriate environment, but it will ensure that the current usage continues to work once the new usage is enabled, ensuring backward compatibility.

Second commit adds a new `dir` argument with `.GlobalEnv$analysis_inputs_path` as the default value (ensuring backward compatibility with existing workflows), but also enables passing the desired value explicitly as an argument (the desired new usage).