### PR TITLE
remove dependence on global `project_location` from `get_input_files()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pacta.portfolio.audit (development version)
 
+* `get_input_files()` gains a `project_location` argument allowing one to explicitly pass the `project_location` value rather than depending on it being available in the global environment, while the default behavior maintains backward compatibility with previous workflows (#18)
+
 * `get_entity_info()` gains a `dir` argument allowing one to explicitly pass the `analysis_inputs_path` value rather than depending on it being available in the global environment, while the default behavior maintains backward compatibility with previous workflows (#17)
 
 * Add vignette/article Attributing Company Activities to Financial Assets (#12)

--- a/R/get_input_files.R
+++ b/R/get_input_files.R
@@ -3,15 +3,18 @@
 #' A longer description of the function
 #'
 #' @param portfolio_name_ref_all A description of the argument
+#' @param project_location A charcter string defining the path to the user's
+#'   data directory, usually "working_dir" and the value held in the
+#'   `project_location` parameter
 #'
 #' @return A description of the return value
 #'
 #' @export
 
-get_input_files <- function(portfolio_name_ref_all) {
+get_input_files <- function(portfolio_name_ref_all, project_location = .GlobalEnv$project_location) {
   portfolio <- tibble()
 
-  input_path <- file.path(.GlobalEnv$project_location, "20_Raw_Inputs")
+  input_path <- file.path(project_location, "20_Raw_Inputs")
 
   # check that the provided reference names match to the input files
 
@@ -49,7 +52,7 @@ get_input_files <- function(portfolio_name_ref_all) {
     stop("Missing input argument")
   }
 
-  portfolio_file_names <- list.files(file.path(.GlobalEnv$project_location, "10_Parameter_File"))
+  portfolio_file_names <- list.files(file.path(project_location, "10_Parameter_File"))
   portfolio_file_names <- portfolio_file_names[grepl("_PortfolioParameters.yml", portfolio_file_names)]
   portfolio_file_names <- gsub("_PortfolioParameters.yml", "", portfolio_file_names)
 

--- a/man/get_input_files.Rd
+++ b/man/get_input_files.Rd
@@ -4,10 +4,17 @@
 \alias{get_input_files}
 \title{A short description of the function}
 \usage{
-get_input_files(portfolio_name_ref_all)
+get_input_files(
+  portfolio_name_ref_all,
+  project_location = .GlobalEnv$project_location
+)
 }
 \arguments{
 \item{portfolio_name_ref_all}{A description of the argument}
+
+\item{project_location}{A charcter string defining the path to the user's
+data directory, usually "working_dir" and the value held in the
+\code{project_location} parameter}
 }
 \value{
 A description of the return value

--- a/tests/testthat/test-get_input_files.R
+++ b/tests/testthat/test-get_input_files.R
@@ -1,0 +1,44 @@
+test_that("works as expected with global `project_location`", {
+  with_test_env <- function(code) {
+    dir.create(file.path(tempdir(), "10_Parameter_File"))
+    dir.create(file.path(tempdir(), "20_Raw_Inputs"))
+
+    port_param_yml <- "default:\n    parameters:\n        portfolio_name: TestPortfolio_Input\n        investor_name: Test\n        peer_group: bank\n        language: EN\n        project_code: PA2022CH\n        holdings_date:\n            - 2021Q4"
+    writeLines(port_param_yml, file.path(tempdir(), "10_Parameter_File", "1234_PortfolioParameters.yml"))
+
+    port_csv <- "Investor.Name,Portfolio.Name,ISIN,MarketValue,Currency\nZZZ,XXX,JP3868400007,50000,GBP"
+    writeLines(port_csv, file.path(tempdir(), "20_Raw_Inputs", "1234.csv"))
+
+    if (exists("project_location", envir = .GlobalEnv)) {
+      old <- .GlobalEnv$project_location
+      .GlobalEnv$project_location <- tempdir()
+      on.exit({
+        .GlobalEnv$project_location <- old
+        unlink(file.path(tempdir(), "10_Parameter_File"), recursive = TRUE)
+        unlink(file.path(tempdir(), "20_Raw_Inputs"), recursive = TRUE)
+      })
+    } else {
+      .GlobalEnv$project_location <- tempdir()
+      on.exit({
+        rm(project_location, envir = .GlobalEnv)
+        unlink(file.path(tempdir(), "10_Parameter_File"), recursive = TRUE)
+        unlink(file.path(tempdir(), "20_Raw_Inputs"), recursive = TRUE)
+      })
+    }
+
+    force(code)
+  }
+
+  expect_no_error(
+    with_test_env(get_input_files(portfolio_name_ref_all = "1234"))
+  )
+
+  expect_equal(
+    with_test_env(get_input_files(portfolio_name_ref_all = "1234")),
+    tibble::tribble(
+      ~isin, ~market_value, ~currency,
+      "JP3868400007",         50000,     "GBP"
+    ),
+    ignore_attr = TRUE
+  )
+})


### PR DESCRIPTION
First commit adds a test so that the current usage, i.e. [`get_input_files(portfolio_name_ref_all)`](https://github.com/RMI-PACTA/workflow.transition.monitor/blob/d444999e287289b62f705c2c1fb4b36147efa6de/web_tool_script_1.R#L72), works as expected with a dependence on a `project_location` object being available in the global environment. This required a convoluted test to safely construct and teardown an appropriate environment, but it will ensure that the current usage continues to work once the new usage is enabled, ensuring backward compatibility.

Second commit adds a new `project_location` argument with `.GlobalEnv$project_location` as the default value (ensuring backward compatibility with existing workflows), but also enables passing the desired value explicitly as an argument (the desired new usage).