### PR TITLE
Fix/45 pass currencies explicitly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.portfolio.audit
 Title: Functions for Calculating Audit Statistics for PACTA on Capital Transition Monitor
-Version: 0.0.1.9001
+Version: 0.0.1.9000
 Authors@R: 
     c(person(given = "CJ",
              family = "Yetman",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.portfolio.audit
 Title: Functions for Calculating Audit Statistics for PACTA on Capital Transition Monitor
-Version: 0.0.1.9000
+Version: 0.0.1.9001
 Authors@R: 
     c(person(given = "CJ",
              family = "Yetman",

--- a/R/add_portfolio_flags.R
+++ b/R/add_portfolio_flags.R
@@ -5,7 +5,7 @@
 #' financial data.
 #'
 #' @param portfolio A data frame containing a portfolio
-#' @param currencies A data frame containing a currencies and their exchange
+#' @param currencies A data frame containing ISO 4217 currency codes and their exchange
 #' rates.
 #'
 #' @return A data frame of the portfolio with the flags columns added

--- a/R/add_portfolio_flags.R
+++ b/R/add_portfolio_flags.R
@@ -5,16 +5,21 @@
 #' financial data.
 #'
 #' @param portfolio A data frame containing a portfolio
+#' @param currencies A data frame containing a currencies and their exchange
+#' rates.
 #'
 #' @return A data frame of the portfolio with the flags columns added
 #'
 #' @export
 
-add_portfolio_flags <- function(portfolio) {
+add_portfolio_flags <- function(
+  portfolio,
+  currencies
+) {
   ### FLAGS/Exclusions
 
   portfolio <- check_isin_format(portfolio)
-  portfolio <- check_missing_currency(portfolio)
+  portfolio <- check_missing_currency(portfolio, currencies)
   portfolio <- check_valid_input_value(portfolio)
   portfolio <- check_financial_data(portfolio)
 

--- a/R/check_missing_currency.R
+++ b/R/check_missing_currency.R
@@ -1,4 +1,7 @@
-check_missing_currency <- function(portfolio_total) {
+check_missing_currency <- function(
+  portfolio_total,
+  currencies
+  ) {
   # Currency blank or not in our currency data frame
   portfolio_total %>%
     mutate(has_currency = case_when(

--- a/man/add_portfolio_flags.Rd
+++ b/man/add_portfolio_flags.Rd
@@ -4,10 +4,13 @@
 \alias{add_portfolio_flags}
 \title{Adds flags columns to a portfolio data frame}
 \usage{
-add_portfolio_flags(portfolio)
+add_portfolio_flags(portfolio, currencies)
 }
 \arguments{
 \item{portfolio}{A data frame containing a portfolio}
+
+\item{currencies}{A data frame containing a currencies and their exchange
+rates.}
 }
 \value{
 A data frame of the portfolio with the flags columns added

--- a/man/add_portfolio_flags.Rd
+++ b/man/add_portfolio_flags.Rd
@@ -9,7 +9,7 @@ add_portfolio_flags(portfolio, currencies)
 \arguments{
 \item{portfolio}{A data frame containing a portfolio}
 
-\item{currencies}{A data frame containing a currencies and their exchange
+\item{currencies}{A data frame containing ISO 4217 currency codes and their exchange
 rates.}
 }
 \value{


### PR DESCRIPTION
Pass `currencies` object explicitly to `check_missing_currency()`

closes #45